### PR TITLE
Handle builds without Python headers for leechcorepyc

### DIFF
--- a/leechcorepyc/leechcorepyc.c
+++ b/leechcorepyc/leechcorepyc.c
@@ -5,6 +5,20 @@
 //
 #include "leechcorepyc.h"
 
+#if !LEECHCOREPYC_HAVE_PYTHON
+
+PyObject *g_pPyType_LeechCore = NULL;
+PLC_CONFIG_ERRORINFO g_LEECHCORE_LAST_ERRORINFO = NULL;
+
+// The Python development headers/libraries are not available. Build a no-op
+// module that signals import failure instead of hard compilation errors.
+EXPORTED_FUNCTION PyObject* PyInit_leechcorepyc(void)
+{
+    return NULL;
+}
+
+#else
+
 PyObject *g_pPyType_LeechCore = NULL;
 PLC_CONFIG_ERRORINFO g_LEECHCORE_LAST_ERRORINFO = NULL;  // will be memory leaked - but it should be very rare.
 
@@ -897,3 +911,5 @@ EXPORTED_FUNCTION PyObject* PyInit_leechcorepyc(void)
     }
     return pPyModule;
 }
+
+#endif /* LEECHCOREPYC_HAVE_PYTHON */

--- a/leechcorepyc/leechcorepyc.h
+++ b/leechcorepyc/leechcorepyc.h
@@ -6,6 +6,22 @@
 #ifndef __LEECHCOREPYC_H__
 #define __LEECHCOREPYC_H__
 
+#include <leechcore.h>
+#include "oscompatibility.h"
+
+#if !defined(LEECHCOREPYC_HAVE_PYTHON)
+#if defined(__has_include)
+#if __has_include(<Python.h>)
+#define LEECHCOREPYC_HAVE_PYTHON 1
+#else
+#define LEECHCOREPYC_HAVE_PYTHON 0
+#endif
+#else
+#define LEECHCOREPYC_HAVE_PYTHON 1
+#endif
+#endif /* !defined(LEECHCOREPYC_HAVE_PYTHON) */
+
+#if LEECHCOREPYC_HAVE_PYTHON
 #define PY_SSIZE_T_CLEAN
 #define Py_LIMITED_API 0x03060000
 #ifdef _DEBUG
@@ -17,11 +33,26 @@
 #include <Python.h>
 #include <structmember.h>
 #endif
+#else
+#include <stddef.h>
 #ifdef _WIN32
 #include <Windows.h>
 #endif /* _WIN32 */
-#include <leechcore.h>
-#include "oscompatibility.h"
+typedef ptrdiff_t Py_ssize_t;
+typedef struct _fakePyTypeObject PyTypeObject;
+typedef struct _fakePyObject {
+    Py_ssize_t ob_refcnt;
+    PyTypeObject *ob_type;
+} PyObject;
+struct _fakePyTypeObject {
+    int unused;
+};
+#define PyObject_HEAD Py_ssize_t ob_refcnt; PyTypeObject *ob_type;
+#endif
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif /* _WIN32 */
 
 extern PyObject *g_pPyType_LeechCore;
 extern PyObject *g_pPyType_BarRequest;

--- a/leechcorepyc/leechcorepyc_barrequest.c
+++ b/leechcorepyc/leechcorepyc_barrequest.c
@@ -6,6 +6,27 @@
 
 #include "leechcorepyc.h"
 
+#if !LEECHCOREPYC_HAVE_PYTHON
+
+PyObject *g_pPyType_BarRequest = NULL;
+
+// Without Python we cannot expose the BAR request helpers. Return NULL/FAIL so
+// higher level code can detect the missing functionality gracefully.
+PyObj_BarRequest* LcPy_BarRequest_InitializeInternal(_In_ PyObj_LeechCore *pyLC, _In_ PLC_BAR_REQUEST pReq)
+{
+    (void)pyLC;
+    (void)pReq;
+    return NULL;
+}
+
+_Success_(return) BOOL LcPy_BarRequest_InitializeType(PyObject *pModule)
+{
+    (void)pModule;
+    return FALSE;
+}
+
+#else
+
 PyObject *g_pPyType_BarRequest = NULL;
 
 // (PBYTE) -> None
@@ -213,3 +234,5 @@ BOOL LcPy_BarRequest_InitializeType(PyObject *pModule)
     }
     return g_pPyType_BarRequest ? TRUE : FALSE;
 }
+
+#endif /* LEECHCOREPYC_HAVE_PYTHON */

--- a/leechcorepyc/leechcorepyemb.c
+++ b/leechcorepyc/leechcorepyemb.c
@@ -6,17 +6,14 @@
 // (c) Ulf Frisk, 2020-2025
 // Author: Ulf Frisk, pcileech@frizk.net
 //
-#define Py_LIMITED_API 0x03060000
-#ifdef _DEBUG
-#undef _DEBUG
-#include <python.h>
-#define _DEBUG
-#else
-#include <python.h>
-#endif
-#include <Windows.h>
-#include <leechcore.h>
 #include "leechcorepyc.h"
+
+#if LEECHCOREPYC_HAVE_PYTHON
+
+#if defined(_WIN32)
+#include <Windows.h>
+#endif
+#include <leechcore.h>
 
 #define PYTHON_PATH_MAX             7*MAX_PATH
 #define PYTHON_PATH_DELIMITER       L";"
@@ -117,3 +114,31 @@ VOID LeechCorePyC_EmbClose()
         Py_FinalizeEx();
     } __except(EXCEPTION_EXECUTE_HANDLER) { ; }
 }
+
+#else
+
+#if defined(_WIN32)
+#include <Windows.h>
+#endif
+
+// Stub implementations used when Python headers/libraries are unavailable.
+__declspec(dllexport)
+BOOL LeechCorePyC_EmbPythonInitialize(_In_ HMODULE hDllPython)
+{
+    (void)hDllPython;
+    return FALSE;
+}
+
+__declspec(dllexport)
+BOOL LeechCorePyC_EmbExecPyInMem(_In_ LPSTR szPythonProgram)
+{
+    (void)szPythonProgram;
+    return FALSE;
+}
+
+__declspec(dllexport)
+VOID LeechCorePyC_EmbClose()
+{
+}
+
+#endif /* LEECHCOREPYC_HAVE_PYTHON */


### PR DESCRIPTION
## Summary
- detect the availability of Python headers in `leechcorepyc.h` and provide lightweight stand-ins when they are missing
- supply stub implementations for the Python-dependent modules so the Windows build can succeed without the Python tooling installed

## Testing
- Not run (msbuild LeechCore.sln /m /p:Configuration=Release /p:Platform=x64) (requires Windows build environment)


------
https://chatgpt.com/codex/tasks/task_b_68e53a9613cc832390688238028329cf