### PR TITLE
Handle missing W drive in leechcorepyc post-build step

### DIFF
--- a/leechcorepyc/leechcorepyc.vcxproj
+++ b/leechcorepyc/leechcorepyc.vcxproj
@@ -167,9 +167,9 @@
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>copy $(OutDir)test.py W:\bin /y
-copy $(OutDir)leechcore.dll W:\bin /y
-copy $(OutDir)leechcorepyc.pyd W:\bin /y
+      <Command>if exist W:\bin\ copy $(OutDir)test.py W:\bin /y
+if exist W:\bin\ copy $(OutDir)leechcore.dll W:\bin /y
+if exist W:\bin\ copy $(OutDir)leechcorepyc.pyd W:\bin /y
 copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
 </Command>
     </PostBuildEvent>
@@ -223,9 +223,9 @@ copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>copy $(OutDir)test.py W:\bin /y
-copy $(OutDir)leechcore.dll W:\bin /y
-copy $(OutDir)leechcorepyc.pyd W:\bin /y
+      <Command>if exist W:\bin\ copy $(OutDir)test.py W:\bin /y
+if exist W:\bin\ copy $(OutDir)leechcore.dll W:\bin /y
+if exist W:\bin\ copy $(OutDir)leechcorepyc.pyd W:\bin /y
 copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
 </Command>
     </PostBuildEvent>
@@ -275,9 +275,9 @@ copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>copy $(OutDir)test.py W:\bin /y
-copy $(OutDir)leechcore.dll W:\bin /y
-copy $(OutDir)leechcorepyc.pyd W:\bin /y
+      <Command>if exist W:\bin\ copy $(OutDir)test.py W:\bin /y
+if exist W:\bin\ copy $(OutDir)leechcore.dll W:\bin /y
+if exist W:\bin\ copy $(OutDir)leechcorepyc.pyd W:\bin /y
 copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
 </Command>
     </PostBuildEvent>


### PR DESCRIPTION
## Summary
- guard the leechcorepyc post-build copies to W:\bin so they only run when the drive is available
- keep the existing copy to the agent plugin directory unchanged

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e53ef5018883239ef21fc06377a4d9