### PR TITLE
Fix leechcorepyc post-build plugin copy

### DIFF
--- a/leechcorepyc/leechcorepyc.vcxproj
+++ b/leechcorepyc/leechcorepyc.vcxproj
@@ -167,10 +167,13 @@
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>if exist W:\bin\ copy $(OutDir)test.py W:\bin /y
-if exist W:\bin\ copy $(OutDir)leechcore.dll W:\bin /y
-if exist W:\bin\ copy $(OutDir)leechcorepyc.pyd W:\bin /y
-copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
+      <Command>if exist W:\bin\ (
+copy "$(OutDir)test.py" W:\bin /y
+copy "$(OutDir)leechcore.dll" W:\bin /y
+copy "$(OutDir)leechcorepyc.pyd" W:\bin /y
+)
+if not exist "$(OutDir)agent\x64\Plugins\leechcorepyc\" mkdir "$(OutDir)agent\x64\Plugins\leechcorepyc\"
+copy "$(OutDir)leechcorepyc.pyd" "$(OutDir)agent\x64\Plugins\leechcorepyc\" /y
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -223,10 +226,13 @@ copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>if exist W:\bin\ copy $(OutDir)test.py W:\bin /y
-if exist W:\bin\ copy $(OutDir)leechcore.dll W:\bin /y
-if exist W:\bin\ copy $(OutDir)leechcorepyc.pyd W:\bin /y
-copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
+      <Command>if exist W:\bin\ (
+copy "$(OutDir)test.py" W:\bin /y
+copy "$(OutDir)leechcore.dll" W:\bin /y
+copy "$(OutDir)leechcorepyc.pyd" W:\bin /y
+)
+if not exist "$(OutDir)agent\x64\Plugins\leechcorepyc\" mkdir "$(OutDir)agent\x64\Plugins\leechcorepyc\"
+copy "$(OutDir)leechcorepyc.pyd" "$(OutDir)agent\x64\Plugins\leechcorepyc\" /y
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -275,10 +281,13 @@ copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>if exist W:\bin\ copy $(OutDir)test.py W:\bin /y
-if exist W:\bin\ copy $(OutDir)leechcore.dll W:\bin /y
-if exist W:\bin\ copy $(OutDir)leechcorepyc.pyd W:\bin /y
-copy $(OutDir)leechcorepyc.pyd $(OutDir)\agent\x64\Plugins\leechcorepyc\ /y
+      <Command>if exist W:\bin\ (
+copy "$(OutDir)test.py" W:\bin /y
+copy "$(OutDir)leechcore.dll" W:\bin /y
+copy "$(OutDir)leechcorepyc.pyd" W:\bin /y
+)
+if not exist "$(OutDir)agent\x64\Plugins\leechcorepyc\" mkdir "$(OutDir)agent\x64\Plugins\leechcorepyc\"
+copy "$(OutDir)leechcorepyc.pyd" "$(OutDir)agent\x64\Plugins\leechcorepyc\" /y
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
## Summary
- ensure the leechcorepyc post-build step creates the plugin output directory before copying
- group the optional W:\bin\ copies under a single existence check to avoid unnecessary failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5454f503c8323be484beb15e72d4f