### PR TITLE
Enhance FPGA logging and default log path

### DIFF
--- a/leechcore/device_fpga.c
+++ b/leechcore/device_fpga.c
@@ -1218,6 +1218,13 @@ BOOL DeviceFPGA_ConfigRead(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, _
     DWORD i, j, status, dwStatus, dwData, cbRxTx = 0;
     PDWORD pdwData;
     WORD wAddr;
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+            "FPGA ConfigRead: base=0x%04x size=0x%x flags=0x%04x",
+            (unsigned int)wBaseAddr,
+            (unsigned int)cb,
+            (unsigned int)flags);
+    }
     if(!cb || (wBaseAddr + cb > 0x1000)) { goto fail; }
     if(!(pbRxTx = LocalAlloc(LMEM_ZEROINIT, 0x20000))) { goto fail; }
     // WRITE requests
@@ -1272,6 +1279,15 @@ BOOL DeviceFPGA_ConfigRead(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, _
     fReturn = TRUE;
 fail:
     LocalFree(pbRxTx);
+    if(fReturn) {
+        LcLogDumpBuffer(LEECHCORE_LOG_LEVEL_MINIMUM, "FPGA ConfigRead data ", (QWORD)wBaseAddr, pb, cb);
+    } else if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+            "FPGA ConfigRead FAILED: base=0x%04x size=0x%x flags=0x%04x",
+            (unsigned int)wBaseAddr,
+            (unsigned int)cb,
+            (unsigned int)flags);
+    }
     return fReturn;
 }
 
@@ -1289,6 +1305,16 @@ BOOL DeviceFPGA_ConfigWriteEx(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr
 {
     DWORD status, cbTx;
     BYTE pbTx[0x8];
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+            "FPGA ConfigWriteEx: base=0x%04x flags=0x%04x data=%02x %02x mask=%02x %02x",
+            (unsigned int)wBaseAddr,
+            (unsigned int)flags,
+            pbData ? pbData[0] : 0,
+            pbData ? pbData[1] : 0,
+            pbMask ? pbMask[0] : 0,
+            pbMask ? pbMask[1] : 0);
+    }
     // WRITE requests
     pbTx[0] = pbData[0];                            // [0] = byte_value_addr
     pbTx[1] = pbData[1];                            // [1] = byte_value_addr+1
@@ -1299,6 +1325,12 @@ BOOL DeviceFPGA_ConfigWriteEx(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr
     pbTx[6] = 0x20 | (flags & 0x03);                // [6] = target = bit[0:1], read = bit[4], write = bit[5]
     pbTx[7] = 0x77;                                 // [7] = MAGIC 0x77
     status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbTx, 8, &cbTx, NULL);
+    if(status && LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+            "FPGA ConfigWriteEx FAILED: base=0x%04x status=0x%08x",
+            (unsigned int)wBaseAddr,
+            (unsigned int)status);
+    }
     return (status == 0);
 }
 
@@ -1317,7 +1349,24 @@ BOOL DeviceFPGA_ConfigWrite(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, 
     BYTE pbTx[0x800];
     DWORD status, cbTx = 0;
     WORD i = 0, wAddr;
-    if(!cb || (wBaseAddr + cb > 0x1000)) { return FALSE; }
+    if(!cb || (wBaseAddr + cb > 0x1000)) {
+        if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+            LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+                "FPGA ConfigWrite INVALID PARAM: base=0x%04x size=0x%x flags=0x%04x",
+                (unsigned int)wBaseAddr,
+                (unsigned int)cb,
+                (unsigned int)flags);
+        }
+        return FALSE;
+    }
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+            "FPGA ConfigWrite: base=0x%04x size=0x%x flags=0x%04x",
+            (unsigned int)wBaseAddr,
+            (unsigned int)cb,
+            (unsigned int)flags);
+        LcLogDumpBuffer(LEECHCORE_LOG_LEVEL_MINIMUM, "FPGA ConfigWrite data ", (QWORD)wBaseAddr, pb, cb);
+    }
     // BYTE ALIGN (if required)
     if(wBaseAddr % 2) {
         wAddr = (wBaseAddr - 1) | (flags & 0xC000);
@@ -1346,13 +1395,29 @@ BOOL DeviceFPGA_ConfigWrite(_In_ PDEVICE_CONTEXT_FPGA ctx, _In_ WORD wBaseAddr, 
         cbTx += 8;
         if(cbTx >= 0x3f0) {
             status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbTx, cbTx, &cbTx, NULL);
-            if(status) { return FALSE; }
+            if(status) {
+                if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+                    LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+                        "FPGA ConfigWrite FAILED: base=0x%04x status=0x%08x",
+                        (unsigned int)(wBaseAddr + i),
+                        (unsigned int)status);
+                }
+                return FALSE;
+            }
             cbTx = 0;
         }
     }
     if(cbTx) {
         status = ctx->dev.pfnFT_WritePipe(ctx->dev.hFTDI, 0x02, pbTx, cbTx, &cbTx, NULL);
-        if(status) { return FALSE; }
+        if(status) {
+            if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+                LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+                    "FPGA ConfigWrite FAILED: base=0x%04x status=0x%08x",
+                    (unsigned int)(wBaseAddr + i),
+                    (unsigned int)status);
+            }
+            return FALSE;
+        }
     }
     return TRUE;
 }
@@ -3277,13 +3342,40 @@ fail:
 VOID DeviceFPGA_ReadScatter_DoLock(_In_ PLC_CONTEXT ctxLC, _In_ DWORD cMEMs, _Inout_ PPMEM_SCATTER ppMEMs)
 {
     PDEVICE_CONTEXT_FPGA ctx = (PDEVICE_CONTEXT_FPGA)ctxLC->hDevice;
-    if(!ctx->wDeviceId) { return; }
+    DWORD i;
+    PMEM_SCATTER pMEM;
+    if(!ctx->wDeviceId) {
+        if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+            LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM, "FPGA ReadScatter skipped: device not initialized");
+        }
+        return;
+    }
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM, "FPGA ReadScatter request: entries=%lu", (unsigned long)cMEMs);
+        for(i = 0; i < cMEMs; i++) {
+            pMEM = ppMEMs[i];
+            if(!pMEM || MEM_SCATTER_ADDR_ISINVALID(pMEM)) { continue; }
+            LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+                "  req[%lu]: pa=0x%016llx size=0x%x", (unsigned long)i, (unsigned long long)pMEM->qwA, pMEM->cb);
+        }
+    }
     if(ctx->async2.fEnabled) {
         DeviceFPGA_Async2_ReadScatter(ctxLC, cMEMs, ppMEMs, ctx->perf.RETRY_ON_ERROR);
     } else {
         EnterCriticalSection(&ctx->Lock);
         DeviceFPGA_Synch_ReadScatter(ctxLC, cMEMs, ppMEMs);
         LeaveCriticalSection(&ctx->Lock);
+    }
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        for(i = 0; i < cMEMs; i++) {
+            pMEM = ppMEMs[i];
+            if(!pMEM || MEM_SCATTER_ADDR_ISINVALID(pMEM)) { continue; }
+            LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+                "  rsp[%lu]: status=%s", (unsigned long)i, pMEM->f ? "ok" : "err");
+            if(pMEM->f) {
+                LcLogDumpBuffer(LEECHCORE_LOG_LEVEL_MINIMUM, "    data ", pMEM->qwA, pMEM->pb, pMEM->cb);
+            }
+        }
     }
 }
 
@@ -3378,6 +3470,7 @@ BOOL DeviceFPGA_WriteMEM_TXP(_In_ PLC_CONTEXT ctxLC, _Inout_ PDEVICE_CONTEXT_FPG
     PBYTE pbTlp = (PBYTE)txbuf;
     PTLP_HDR_MRdWr32 hdrWr32 = (PTLP_HDR_MRdWr32)txbuf;
     PTLP_HDR_MRdWr64 hdrWr64 = (PTLP_HDR_MRdWr64)txbuf;
+    BOOL fResult;
     bTag++;
     if(bTag == 0) {
         bTag = 0xe0;
@@ -3413,11 +3506,21 @@ BOOL DeviceFPGA_WriteMEM_TXP(_In_ PLC_CONTEXT ctxLC, _Inout_ PDEVICE_CONTEXT_FPG
         memcpy(pbTlp + 16, pb, cb);
         cbTlp = (16 + cb + 3) & ~0x3;
     }
-    if(ctx->perf.FLAGS & DEVICE_PERFORMANCE_FLAG_FASTWRITE) {
-        return DeviceFPGA_TxTlp_FastWrite_NoLock(ctxLC, ctx, pbTlp, cbTlp, FALSE, FALSE);
-    } else {
-        return DeviceFPGA_TxTlp(ctxLC, ctx, pbTlp, cbTlp, FALSE, FALSE);
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_VERBOSE)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_VERBOSE,
+            "FPGA WriteMEM_TXP: pa=0x%016llx size=0x%x firstBE=0x%02x lastBE=0x%02x", (unsigned long long)pa, cb, bFirstBE, bLastBE);
+        LcLogDumpBuffer(LEECHCORE_LOG_LEVEL_VERBOSE, "    payload ", pa, pb, cb);
     }
+    if(ctx->perf.FLAGS & DEVICE_PERFORMANCE_FLAG_FASTWRITE) {
+        fResult = DeviceFPGA_TxTlp_FastWrite_NoLock(ctxLC, ctx, pbTlp, cbTlp, FALSE, FALSE);
+    } else {
+        fResult = DeviceFPGA_TxTlp(ctxLC, ctx, pbTlp, cbTlp, FALSE, FALSE);
+    }
+    if(!fResult && LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+            "FPGA WriteMEM_TXP FAILED: pa=0x%016llx size=0x%x", (unsigned long long)pa, cb);
+    }
+    return fResult;
 }
 
 VOID DeviceFPGA_WriteScatter(_In_ PLC_CONTEXT ctxLC, _In_ DWORD cpMEMs, _Inout_ PPMEM_SCATTER ppMEMs)
@@ -3470,6 +3573,18 @@ VOID DeviceFPGA_WriteScatter(_In_ PLC_CONTEXT ctxLC, _In_ DWORD cpMEMs, _Inout_ 
 VOID DeviceFPGA_WriteScatter_DoLock(_In_ PLC_CONTEXT ctxLC, _In_ DWORD cpMEMs, _Inout_ PPMEM_SCATTER ppMEMs)
 {
     PDEVICE_CONTEXT_FPGA ctx = (PDEVICE_CONTEXT_FPGA)ctxLC->hDevice;
+    DWORD i;
+    PMEM_SCATTER pMEM;
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM, "FPGA WriteScatter request: entries=%lu", (unsigned long)cpMEMs);
+        for(i = 0; i < cpMEMs; i++) {
+            pMEM = ppMEMs[i];
+            if(!pMEM || MEM_SCATTER_ADDR_ISINVALID(pMEM)) { continue; }
+            LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+                "  req[%lu]: pa=0x%016llx size=0x%x", (unsigned long)i, (unsigned long long)pMEM->qwA, pMEM->cb);
+            LcLogDumpBuffer(LEECHCORE_LOG_LEVEL_MINIMUM, "    data ", pMEM->qwA, pMEM->pb, pMEM->cb);
+        }
+    }
     if(ctx->perf.FLAGS & DEVICE_PERFORMANCE_FLAG_FASTWRITE) {
         DeviceFPGA_WriteScatter(ctxLC, cpMEMs, ppMEMs);
     } else if(ctx->async2.fEnabled) {
@@ -3478,6 +3593,14 @@ VOID DeviceFPGA_WriteScatter_DoLock(_In_ PLC_CONTEXT ctxLC, _In_ DWORD cpMEMs, _
         EnterCriticalSection(&ctx->Lock);
         DeviceFPGA_WriteScatter(ctxLC, cpMEMs, ppMEMs);
         LeaveCriticalSection(&ctx->Lock);
+    }
+    if(LcLogIsEnabled(LEECHCORE_LOG_LEVEL_MINIMUM)) {
+        for(i = 0; i < cpMEMs; i++) {
+            pMEM = ppMEMs[i];
+            if(!pMEM || MEM_SCATTER_ADDR_ISINVALID(pMEM)) { continue; }
+            LcLogMessage(LEECHCORE_LOG_LEVEL_MINIMUM,
+                "  rsp[%lu]: status=%s", (unsigned long)i, pMEM->f ? "ok" : "err");
+        }
     }
 }
 

--- a/leechcore/leechcore.c
+++ b/leechcore/leechcore.c
@@ -16,6 +16,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
 
 //-----------------------------------------------------------------------------
 // Global Context and DLL Attach/Detach:
@@ -39,8 +43,6 @@ LC_MAIN_CONTEXT g_ctx = { 0 };
 //-----------------------------------------------------------------------------
 
 #define LEECHCORE_LOG_DEFAULT_FILENAME      "leechcore.log"
-#define LEECHCORE_LOG_LEVEL_MINIMUM         0
-#define LEECHCORE_LOG_LEVEL_VERBOSE         2
 
 static BOOL LcLogGetEnvString(_In_ LPCSTR szName, _Out_writes_(cchBuffer) LPSTR szValue, _In_ SIZE_T cchBuffer)
 {
@@ -101,6 +103,42 @@ static VOID LcLogFormatTimestamp(_Out_writes_(cchBuffer) LPSTR szBuffer, _In_ SI
     }
 }
 
+static BOOL LcLogPathIsDirectory(_In_z_ LPCSTR szPath)
+{
+#ifdef _WIN32
+    DWORD dwAttr = GetFileAttributesA(szPath);
+    return (dwAttr != INVALID_FILE_ATTRIBUTES) && (dwAttr & FILE_ATTRIBUTE_DIRECTORY);
+#else
+    struct stat st = { 0 };
+    return (0 == stat(szPath, &st)) && S_ISDIR(st.st_mode);
+#endif
+}
+
+static VOID LcLogEnsureTrailingSeparator(_Inout_updates_(cchPath) LPSTR szPath, _In_ SIZE_T cchPath)
+{
+    SIZE_T cch = strlen(szPath);
+    if(!cch) { return; }
+    if((szPath[cch - 1] == '\\') || (szPath[cch - 1] == '/')) { return; }
+#ifdef _WIN32
+    strncat_s(szPath, cchPath, "\\", _TRUNCATE);
+#else
+    strncat_s(szPath, cchPath, "/", _TRUNCATE);
+#endif
+}
+
+static BOOL LcLogGetCurrentDirectory(_Out_writes_(cchPath) LPSTR szPath, _In_ SIZE_T cchPath)
+{
+    ZeroMemory(szPath, cchPath);
+#ifdef _WIN32
+    DWORD cch = GetCurrentDirectoryA((DWORD)cchPath, szPath);
+    if(!cch || (cch >= cchPath)) { return FALSE; }
+#else
+    if(!getcwd(szPath, cchPath)) { return FALSE; }
+#endif
+    LcLogEnsureTrailingSeparator(szPath, cchPath);
+    return TRUE;
+}
+
 static VOID LcLogInitialize()
 {
     CHAR szPath[MAX_PATH] = { 0 };
@@ -109,12 +147,30 @@ static VOID LcLogInitialize()
     if(g_ctx.fLogInitialized) { return; }
     g_ctx.fLogInitialized = TRUE;
     if(LcLogGetEnvDword("LEECHCORE_LOG_DISABLE", 0)) { return; }
-    if(!LcLogGetEnvString("LEECHCORE_LOG_PATH", szPath, _countof(szPath))) {
-        Util_GetPathLib(szFolder);
-        if(szFolder[0]) {
-            strncpy_s(szPath, _countof(szPath), szFolder, _TRUNCATE);
+    if(LcLogGetEnvString("LEECHCORE_LOG_PATH", szPath, _countof(szPath))) {
+        SIZE_T cch = strlen(szPath);
+        if(cch && ((szPath[cch - 1] == '\\') || (szPath[cch - 1] == '/'))) {
+            LcLogEnsureTrailingSeparator(szPath, _countof(szPath));
+            strncat_s(szPath, _countof(szPath), LEECHCORE_LOG_DEFAULT_FILENAME, _TRUNCATE);
+        } else if(LcLogPathIsDirectory(szPath)) {
+            LcLogEnsureTrailingSeparator(szPath, _countof(szPath));
+            strncat_s(szPath, _countof(szPath), LEECHCORE_LOG_DEFAULT_FILENAME, _TRUNCATE);
         }
-        strncat_s(szPath, _countof(szPath), LEECHCORE_LOG_DEFAULT_FILENAME, _TRUNCATE);
+    } else {
+        if(LcLogGetCurrentDirectory(szFolder, _countof(szFolder))) {
+            strncpy_s(szPath, _countof(szPath), szFolder, _TRUNCATE);
+        } else {
+            Util_GetPathLib(szFolder);
+            if(szFolder[0]) {
+                strncpy_s(szPath, _countof(szPath), szFolder, _TRUNCATE);
+            }
+        }
+        if(!szPath[0]) {
+            strncpy_s(szPath, _countof(szPath), LEECHCORE_LOG_DEFAULT_FILENAME, _TRUNCATE);
+        } else {
+            LcLogEnsureTrailingSeparator(szPath, _countof(szPath));
+            strncat_s(szPath, _countof(szPath), LEECHCORE_LOG_DEFAULT_FILENAME, _TRUNCATE);
+        }
     }
     if(0 != fopen_s(&pFile, szPath, "a")) { return; }
     g_ctx.pLogFile = pFile;
@@ -148,22 +204,76 @@ static VOID LcLogClose()
     LeaveCriticalSection(&g_ctx.LogLock);
 }
 
-static VOID LcLogWrite(_In_z_ LPCSTR szFormat, ...)
+static VOID LcLogWriteVa(_In_ DWORD dwLevel, _In_z_ LPCSTR szFormat, va_list ap)
 {
-    va_list ap;
-    if(!g_ctx.fLogEnabled || !g_ctx.pLogFile) { return; }
+    if(!g_ctx.fLogEnabled || !g_ctx.pLogFile || (dwLevel > g_ctx.dwLogVerbosity)) { return; }
     EnterCriticalSection(&g_ctx.LogLock);
     if(g_ctx.pLogFile) {
         CHAR szTs[48] = { 0 };
+        va_list apCopy;
         LcLogFormatTimestamp(szTs, _countof(szTs));
         fprintf(g_ctx.pLogFile, "[%s][tid:%llx] ", szTs, (unsigned long long)LcLogGetThreadId());
-        va_start(ap, szFormat);
-        vfprintf(g_ctx.pLogFile, szFormat, ap);
-        va_end(ap);
+        va_copy(apCopy, ap);
+        vfprintf(g_ctx.pLogFile, szFormat, apCopy);
+        va_end(apCopy);
         fputc('\n', g_ctx.pLogFile);
         if(g_ctx.fLogFlush) { fflush(g_ctx.pLogFile); }
     }
     LeaveCriticalSection(&g_ctx.LogLock);
+}
+
+static VOID LcLogWriteBasic(_In_z_ LPCSTR szFormat, ...)
+{
+    va_list ap;
+    va_start(ap, szFormat);
+    LcLogWriteVa(LEECHCORE_LOG_LEVEL_MINIMUM, szFormat, ap);
+    va_end(ap);
+}
+
+BOOL LcLogIsEnabled(_In_ DWORD dwLevel)
+{
+    return g_ctx.fLogEnabled && g_ctx.pLogFile && (dwLevel <= g_ctx.dwLogVerbosity);
+}
+
+VOID LcLogMessage(_In_ DWORD dwLevel, _In_z_ LPCSTR szFormat, ...)
+{
+    va_list ap;
+    va_start(ap, szFormat);
+    LcLogWriteVa(dwLevel, szFormat, ap);
+    va_end(ap);
+}
+
+VOID LcLogDumpBuffer(
+    _In_ DWORD dwLevel,
+    _In_opt_z_ LPCSTR szPrefix,
+    _In_ QWORD qwBaseAddress,
+    _In_reads_opt_(cb) const BYTE *pb,
+    _In_ DWORD cb)
+{
+    const DWORD cbMaxDump = 256;
+    const DWORD cbPerLine = 16;
+    DWORD i, j;
+    CHAR szLine[128];
+    DWORD cbDump;
+    if(!pb || !cb || !LcLogIsEnabled(dwLevel)) { return; }
+    cbDump = (cb > cbMaxDump) ? cbMaxDump : cb;
+    for(i = 0; i < cbDump; i += cbPerLine) {
+        SIZE_T o = 0;
+        DWORD cbLine = (cbDump - i < cbPerLine) ? (cbDump - i) : cbPerLine;
+        o += _snprintf_s(szLine + o, _countof(szLine) - o, _TRUNCATE, "%s0x%016llx:",
+            szPrefix ? szPrefix : "",
+            (unsigned long long)(qwBaseAddress + i));
+        for(j = 0; j < cbLine; j++) {
+            o += _snprintf_s(szLine + o, _countof(szLine) - o, _TRUNCATE, " %02x", pb[i + j]);
+        }
+        LcLogMessage(dwLevel, "%s", szLine);
+    }
+    if(cbDump < cb) {
+        LcLogMessage(dwLevel,
+            "%s... (%lu bytes truncated - enable verbose logging for full dump)",
+            szPrefix ? szPrefix : "",
+            (unsigned long)(cb - cbDump));
+    }
 }
 
 static double LcLogElapsedMs(_In_opt_ PLC_CONTEXT ctxLC, _In_ QWORD tmStart)
@@ -196,7 +306,7 @@ static VOID LcLogScatterDetails(
 {
     DWORD i;
     if(!g_ctx.fLogEnabled) { return; }
-    LcLogWrite(
+    LcLogWriteBasic(
         "%s: device='%s' handle=%p entries=%lu bytes=0x%llx translated=%u",
         szPhase,
         ctxLC ? ctxLC->Config.szDeviceName : "",
@@ -209,7 +319,7 @@ static VOID LcLogScatterDetails(
     for(i = 0; i < cMEMs; i++) {
         PMEM_SCATTER pMEM = ppMEMs[i];
         QWORD qwOriginal = fTranslated && pMEM->iStack ? MEM_SCATTER_STACK_PEEK(pMEM, 1) : pMEM->qwA;
-        LcLogWrite(
+        LcLogWriteBasic(
             "  [%lu] pa=0x%016llx cb=0x%x status=%s",
             (unsigned long)i,
             (unsigned long long)pMEM->qwA,
@@ -217,7 +327,7 @@ static VOID LcLogScatterDetails(
             fIncludeStatus ? (pMEM->f ? "ok" : "err") : "-"
         );
         if(fTranslated && (qwOriginal != pMEM->qwA)) {
-            LcLogWrite("      original_pa=0x%016llx", (unsigned long long)qwOriginal);
+            LcLogWriteBasic("      original_pa=0x%016llx", (unsigned long long)qwOriginal);
         }
     }
 }
@@ -1049,7 +1159,7 @@ EXPORTED_FUNCTION VOID LcReadScatter(_In_ HANDLE hLC, _In_ DWORD cMEMs, _Inout_ 
     }
     if(g_ctx.fLogEnabled) {
         msElapsed = LcLogElapsedMs(ctxLC, tmStart);
-        LcLogWrite(
+        LcLogWriteBasic(
             "READ_SCATTER_DONE: device='%s' handle=%p entries=%lu bytes=0x%llx duration=%.3fms",
             ctxLC->Config.szDeviceName,
             ctxLC,
@@ -1082,7 +1192,7 @@ EXPORTED_FUNCTION BOOL LcRead(_In_ HANDLE hLC, _In_ QWORD pa, _In_ DWORD cb, _Ou
     if(!ctxLC || ctxLC->version != LC_CONTEXT_VERSION) { return FALSE; }
     if(cb == 0) { return TRUE; }
     if(g_ctx.fLogEnabled) {
-        LcLogWrite(
+        LcLogWriteBasic(
             "READ_BEGIN: device='%s' handle=%p pa=0x%016llx cb=0x%x",
             ctxLC->Config.szDeviceName,
             ctxLC,
@@ -1123,7 +1233,7 @@ EXPORTED_FUNCTION BOOL LcRead(_In_ HANDLE hLC, _In_ QWORD pa, _In_ DWORD cb, _Ou
 fail:
     LocalFree(ppMEMs);
     if(g_ctx.fLogEnabled) {
-        LcLogWrite(
+        LcLogWriteBasic(
             "READ_DONE: device='%s' handle=%p pa=0x%016llx cb=0x%x success=%u duration=%.3fms",
             ctxLC->Config.szDeviceName,
             ctxLC,
@@ -1232,7 +1342,7 @@ EXPORTED_FUNCTION VOID LcWriteScatter(_In_ HANDLE hLC, _In_ DWORD cMEMs, _Inout_
     }
     if(g_ctx.fLogEnabled) {
         msElapsed = LcLogElapsedMs(ctxLC, tmStart);
-        LcLogWrite(
+        LcLogWriteBasic(
             "WRITE_SCATTER_DONE: device='%s' handle=%p entries=%lu bytes=0x%llx duration=%.3fms",
             ctxLC->Config.szDeviceName,
             ctxLC,
@@ -1263,7 +1373,7 @@ EXPORTED_FUNCTION BOOL LcWrite(_In_ HANDLE hLC, _In_ QWORD pa, _In_ DWORD cb, _I
     QWORD tmStart = LcCallStart();
     if(!ctxLC || ctxLC->version != LC_CONTEXT_VERSION) { goto fail; }
     if(g_ctx.fLogEnabled) {
-        LcLogWrite(
+        LcLogWriteBasic(
             "WRITE_BEGIN: device='%s' handle=%p pa=0x%016llx cb=0x%x",
             ctxLC->Config.szDeviceName,
             ctxLC,
@@ -1299,7 +1409,7 @@ EXPORTED_FUNCTION BOOL LcWrite(_In_ HANDLE hLC, _In_ QWORD pa, _In_ DWORD cb, _I
 fail:
     LocalFree(pbBuffer);
     if(g_ctx.fLogEnabled) {
-        LcLogWrite(
+        LcLogWriteBasic(
             "WRITE_DONE: device='%s' handle=%p pa=0x%016llx cb=0x%x success=%u duration=%.3fms",
             ctxLC->Config.szDeviceName,
             ctxLC,

--- a/leechcore/leechcore_internal.h
+++ b/leechcore/leechcore_internal.h
@@ -70,4 +70,16 @@ BOOL LcMemMap_SetRangesFromText(_In_ PLC_CONTEXT ctxLC, _In_ PBYTE pb, _In_ DWOR
 */
 VOID LcCreate_FetchDeviceParameter(_Inout_ PLC_CONTEXT ctxLC);
 
+#define LEECHCORE_LOG_LEVEL_MINIMUM         0
+#define LEECHCORE_LOG_LEVEL_VERBOSE         2
+
+BOOL LcLogIsEnabled(_In_ DWORD dwLevel);
+VOID LcLogMessage(_In_ DWORD dwLevel, _In_z_ LPCSTR szFormat, ...);
+VOID LcLogDumpBuffer(
+    _In_ DWORD dwLevel,
+    _In_opt_z_ LPCSTR szPrefix,
+    _In_ QWORD qwBaseAddress,
+    _In_reads_opt_(cb) const BYTE *pb,
+    _In_ DWORD cb);
+
 #endif /* __LEECHCORE_INTERNAL_H__ */


### PR DESCRIPTION
## Summary
- ensure the DLL log file defaults to the current working directory when no path is configured and expose reusable logging helpers
- add a reusable buffer dump facility and public logging APIs for other modules to emit structured log output
- extend the FPGA device implementation to log register access, memory scatter transfers, and write transactions with associated addresses and data

## Testing
- make -C leechcore *(fails: missing libusb development package in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e54f3f5c2c832380db6f7322b4fb9d